### PR TITLE
Update config documentation for postgres db.

### DIFF
--- a/docs/basic/server-installation.mdx
+++ b/docs/basic/server-installation.mdx
@@ -109,7 +109,7 @@ Despite all the configurable fields, as a beginner, you only need to modify two 
   ```
 
 :::info
-Ensure `dataSourceName` has non-empty `dbName` and leave `app.conf`'s `dbName` empty.
+For PostgreSQL, make sure `dataSourceName` has non-empty `dbName` and leave the standalone `dbName` field empty like the above example.
 :::
 
   **Please notice:** 

--- a/docs/basic/server-installation.mdx
+++ b/docs/basic/server-installation.mdx
@@ -104,11 +104,11 @@ Despite all the configurable fields, as a beginner, you only need to modify two 
 
   ```ini
   driverName = postgres
-  dataSourceName = "user=postgres password=xxx sslmode=disable dbname="
-  dbName = casdoor
+  dataSourceName = "user=postgres password=xxx host=xx.xx.xxx.xxx port=xxxx sslmode=disable dbname=casdoor"
+  dbName =
   ```
 
-  **Please notice:** You can add Postgres parameters in `dataSourceName`, but please make sure that `dataSourceName` ends with `dbname=`. Or database adapter may crash when you launch Casdoor.
+  **Please notice:** Postgres parameters are input in `app.conf`'s `dataSourceName` field. Ensure `dataSourceName` ends with `dbname=casdoor` and `app.conf`'s `dbName` field is empty or the database adapter may crash when you launch Casdoor.
 
 - Other database...
 

--- a/docs/basic/server-installation.mdx
+++ b/docs/basic/server-installation.mdx
@@ -104,7 +104,7 @@ Despite all the configurable fields, as a beginner, you only need to modify two 
 
   ```ini
   driverName = postgres
-  dataSourceName = "user=postgres password=xxx host=xx.xx.xxx.xxx port=xxxx sslmode=disable dbname=casdoor"
+  dataSourceName = "user=postgres password=postgres host=localhost port=5432 sslmode=disable dbname=casdoor"
   dbName =
   ```
 

--- a/docs/basic/server-installation.mdx
+++ b/docs/basic/server-installation.mdx
@@ -108,7 +108,11 @@ Despite all the configurable fields, as a beginner, you only need to modify two 
   dbName =
   ```
 
-  **Please notice:** Postgres parameters are input in `app.conf`'s `dataSourceName` field. Ensure `dataSourceName` ends with `dbname=casdoor` and `app.conf`'s `dbName` field is empty or the database adapter may crash when you launch Casdoor.
+:::info
+Ensure `dataSourceName` has non-empty `dbName` and leave `app.conf`'s `dbName` empty.
+:::
+
+  **Please notice:** 
 
 - Other database...
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-website/issues/181

Fix: https://github.com/casdoor/casdoor/issues/675#issuecomment-1102836541

Addresses #181 and [casdoor/casdoor#675](https://github.com/casdoor/casdoor/issues/675)

I think some some changes in code may still be needed to properly implement the `-createDatabase` flag, but this fixes the documentation for using postgres DB.