### PR TITLE
fix: wrong directory structure

### DIFF
--- a/docs/integration/elk.md
+++ b/docs/integration/elk.md
@@ -4,7 +4,7 @@ description: Overview of casdoor/elk-auth-casdoor
 keywords: [ELK]
 ---
 
-### Overview of casdoor/elk-auth-casdoor
+## Overview of casdoor/elk-auth-casdoor
 One of the biggest dificiency of ELK (Elasticsearch, Logstash and Kibana) is that originally, these products have no authentication mechanism, so that everyone can visit the kibana dashboard as long as he have the url of kibana, or ES urls. Later ELK integrated an embedded authentication system "Xpack", whose all advanced functions  **are not free** (eg. Oauth, OIDC, LDAP, SAML), and only plain authentication (setting a set of accounts and passwords) is free of charge, which is quite incovenient. We cannot just provide a unique account for everyone in a corporation.
 
 
@@ -14,7 +14,7 @@ If this user hasn't been correctly authenticated, request will be temporarly cac
 
 Location of casdoor/elk-auth-casdoor repository <https://github.com/casdoor/elk-auth-casdoor>
 
-### How to run it?
+## How to run it?
 
 0. have golang environment installed
 

--- a/docs/provider/oauth/DingTalk.md
+++ b/docs/provider/oauth/DingTalk.md
@@ -4,7 +4,7 @@ description: Add DingTalk OAuth provider to your application
 keywords: [DingTalk, OAuth]
 ---
 
-### DingTalk:heavy_check_mark:
+## DingTalk:heavy_check_mark:
 
 Visit [DingTalk developer platform](https://open-dev.dingtalk.com/?spm=ding_open_doc.document.0.0.140a645fxfAUAE#/loginMan) and log in using your DingTalk account, after enter the platform, follow the instructions of the platform and you will get your Client Id and Client Secret.
 

--- a/docs/provider/oauth/Steam.md
+++ b/docs/provider/oauth/Steam.md
@@ -4,7 +4,7 @@ description: Add Steam OAuth provider to your application
 keywords: [Steam, OAuth]
 ---
 
-### Steam:heavy_check_mark:
+## Steam:heavy_check_mark:
 
 Visit [Steam WebAPI platform](https://steamcommunity.com/dev/revokekey) and log in using your Steam account, then apply for an API Key for your casdoor domain or ip, and finally fill in your API Key as Client Secret into Casdoor. (ClientID does not need to be filled, and your steam  account needs to have games to apply for the API)
 

--- a/docs/provider/oauth/Tencent.md
+++ b/docs/provider/oauth/Tencent.md
@@ -4,7 +4,7 @@ description: Add Tencent QQ OAuth provider to your application
 keywords: [Tencent QQ, OAuth]
 ---
 
-### Tencent QQ:heavy_check_mark:
+## Tencent QQ:heavy_check_mark:
 
 Visit authentication platform of QQ - [Connect QQ](https://connect.qq.com/manage.html#/).
 

--- a/docs/provider/oauth/Twitter.md
+++ b/docs/provider/oauth/Twitter.md
@@ -4,7 +4,7 @@ description: Add Twitter OAuth provider to your application
 keywords: [Twitter, OAuth]
 ---
 
-###  Twitter(still working🚧)
+##  Twitter(still working🚧)
 
 > Twitter’s application steps are somewhat troublesome, and the official restrictions are a bit strict, so it may be more difficult to apply for a developer account than other third-party platforms.
 

--- a/docs/provider/oauth/Wechat.md
+++ b/docs/provider/oauth/Wechat.md
@@ -4,7 +4,7 @@ description: Add Wechat OAuth provider to your application
 keywords: [Wechat, OAuth]
 ---
 
-### WeChat:heavy_check_mark:
+## WeChat:heavy_check_mark:
 
 Visit [WeChat developer platform](https://open.weixin.qq.com/), register as a developer, after your web application or your mobile application is approved, then you get you App Id and App Secret.
 

--- a/docs/provider/oauth/Weibo.md
+++ b/docs/provider/oauth/Weibo.md
@@ -4,7 +4,7 @@ description: Add Weibo OAuth provider to your application
 keywords: [Weibo, OAuth]
 ---
 
-### Weibo:heavy_check_mark:
+## Weibo:heavy_check_mark:
 
 Weibo's developer account application is not difficult, but the speed is relatively slow, it takes about 2-3 days.
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-website/issues/305

The document should start with a first-level or second-level heading, otherwise it will cause Crowdin to parse incorrectly.
![image](https://user-images.githubusercontent.com/53544726/185919630-353d8d05-2a13-49e4-9a9b-a6f116048a4a.png)

Normally it should be like this:
![image](https://user-images.githubusercontent.com/53544726/185919964-94c6d141-69c6-47c9-9f5d-1b95772fa03a.png)
