### PR TITLE
docs: fix directory error in example run command

### DIFF
--- a/docs/basic/try-with-docker.md
+++ b/docs/basic/try-with-docker.md
@@ -124,7 +124,7 @@ if it is not convenient to mount the configuration file to a container, using en
 Then run 
 
 ```
-docker run  -p 8000:8000 -v /folder/of/app.conf:/conf casbin/casdoor:latest
+docker run  -p 8000:8000 -v /folder/of/app.conf:/conf/app.conf casbin/casdoor:latest
 ```
 
 Anyway just **mount the app.conf to /conf/app.conf** and start it.


### PR DESCRIPTION
When I tried to run this docker container, I found an error about this volume problem.