### PR TITLE
fix: ensure text visible during webfont load

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,7 +14,7 @@
 @font-face {
   font-family: "Inter var";
   font-weight: 100 900;
-  font-display: block;
+  font-display: swap;
   font-style: normal;
   src: url("/fonts/Inter-roman.var.woff2") format("woff2");
 }
@@ -22,6 +22,7 @@
 @font-face {
   font-family: "Fira Code VF";
   font-weight: 300 700;
+  font-display: swap;
   font-style: normal;
   src:
     url("/fonts/FiraCode-VF.woff2") format("woff2-variations"),


### PR DESCRIPTION
https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools

![image](https://user-images.githubusercontent.com/53544726/198037384-735485e7-75f3-4ea8-a30a-75698861bf31.png)
