### PR TITLE
fix: only fetch one git history in action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
 
       - name: Install and Build 🔧 # This example project is built using Yarn and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |


### PR DESCRIPTION
All page' `Last updated ` show the same person, because ci  only fetch one git history .
![image](https://user-images.githubusercontent.com/53544726/200303588-172669da-c637-41c9-acc8-5efd6cdd7941.png)
![image](https://user-images.githubusercontent.com/53544726/200304032-fb0b36b3-f645-446b-a28c-bda6f8aba189.png)

To solve it:
https://github.com/actions/checkout
![image](https://user-images.githubusercontent.com/53544726/200304225-0f9e2441-6151-4999-9ea9-3ba056d7e65a.png)

