### PR TITLE
docs: update reference url in cas.md

### DIFF
--- a/docs/how-to-connect/cas.md
+++ b/docs/how-to-connect/cas.md
@@ -24,7 +24,7 @@ Suppose the endpoint of Casdoor is `https://door.casdoor.com`, which contains an
 - `/p3/proxyValidate` endpoint: `https://door.casdoor.com/cas/casbin/cas-java-app/p3/proxyValidate`
 - `/samlValidate` endpoint: `https://door.casdoor.com/cas/casbin/cas-java-app/samlValidate`
 
-See <https://apereo.github.io/cas/6.0.x/protocol/CAS-Protocol-Specification.html> for more information about CAS and its different versions, as well as parameters for these endpoints.
+See <https://apereo.github.io/cas/6.6.x/protocol/CAS-Protocol-Specification.html> for more information about CAS and its different versions, as well as parameters for these endpoints.
 
 ### An example
 


### PR DESCRIPTION
change `6.0.x` to `6.6.x`. 

`6.0.x` is no longer available.