### PR TITLE
docs: rename "token" to "access_token"

### DIFF
--- a/docs/how-to-connect/oauth.md
+++ b/docs/how-to-connect/oauth.md
@@ -113,7 +113,7 @@ https://<CASDOOR_HOST>/login/oauth/authorize?client_id=CLIENT_ID&redirect_uri=RE
 After your user has authenticated with casdoor, casdoor will redirect him to:
 
 ```
-https://REDIRECT_URI/#token=ACCESS_TOKEN
+https://REDIRECT_URI/#access_token=ACCESS_TOKEN
 ```
 
 Casdoor also supports [id_token](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#id_token) as `response_type`, which is a feature of OpenID.


### PR DESCRIPTION
 Update the param name according to [RFC6749 section 4.2.2 (Access Token Response)](https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2)

casdoor/casdoor#1793
