### PR TITLE
docs: fix incorrect pictures and videos

### DIFF
--- a/docs/application/tags.md
+++ b/docs/application/tags.md
@@ -11,4 +11,6 @@ On the application edit page, you can find the `Tags` configuration section wher
 
 ![configure_tags](/img/application/tags/configure_app_tags.png)
 
-Click [here](/video/application/application_tags.mp4) to download and watch a video demonstrating how application tags work.
+Here is a video demonstrating how application tags work:
+
+<video src="/video/application/application_tags.mp4" controls="controls" width="100%"></video>

--- a/docs/products/payment.md
+++ b/docs/products/payment.md
@@ -9,7 +9,9 @@ After the payment is successfully processed, you will be able to view the transa
 
 ## Invoice
 
-To issue an invoice, navigate to the edit screen by clicking on the following link: [payment_edit.png](/img/products/payment_edit.png).
+To issue an invoice, navigate to the edit screen:
+
+![payment_edit.png](/img/products/payment_edit.png).
 
 On the edit screen, you will need to fill in the relevant invoice information. There are two invoice types available: `individual` and `organization`.
 


### PR DESCRIPTION
The video format is incorrect and cannot be played online. The video has been re-encoded and compressed.