### PR TITLE
chore: update docs on server installation locally

### DIFF
--- a/docs/basic/server-installation.mdx
+++ b/docs/basic/server-installation.mdx
@@ -186,10 +186,16 @@ There are currently two methods to start, and you can choose one according to yo
 
 #### Backend
 
+Casdoor's Go backend requires a database dependency. You can start it by running the following command:
+
+```bash
+make deps
+```
+
 Casdoor's Go backend runs on port 8000 by default. You can start the Go backend with the following command:
 
 ```bash
-go run main.go
+go run main.go --createDatabase=true
 ```
 
 After the server is successfully running, you can start the frontend part.


### PR DESCRIPTION
Improve server installation documentation. Casdoor go service requires a database dependency to be running so adding in docs for it. Also, providing the argument createDatabase as most users won't have the database created by default which would lead to an error