### PR TITLE
chore: add helm chart parameters table

### DIFF
--- a/docs/basic/try-with-helm.md
+++ b/docs/basic/try-with-helm.md
@@ -21,7 +21,7 @@ Now we show how to deploy Casdoor on Kubernetes using Helm for easy and scalable
 Install the Casdoor chart:
 
 ```shell
-helm install casdoor oci://registry-1.docker.io/casbin/casdoor-helm-charts --version 1.502.0
+helm install casdoor oci://registry-1.docker.io/casbin/casdoor-helm-charts --version 1.524.0
 ```
 
 ### Step 2: Accessing Casdoor
@@ -30,7 +30,40 @@ Once installed, Casdoor can be accessed at the provided service URL by your Kube
 
 ### Customization and Configuration
 
-Customize your Casdoor installation by modifying the Helm chart values. For detailed options, refer to the [values.yaml](https://github.com/casdoor/casdoor-helm/blob/master/charts/casdoor/values.yaml) file in the chart.
+Customize your Casdoor installation by modifying the Helm chart values. For detailed options, refer to the [values.yaml](https://github.com/casdoor/casdoor-helm/blob/master/charts/casdoor/values.yaml) file in the chart. The following parameters can be configured.
+
+| Parameter                | Description                                                                                               | Default Value                  |
+|--------------------------|-----------------------------------------------------------------------------------------------------------|--------------------------------|
+| `replicaCount`           | Number of replicas of the Casdoor application to run.                                                     | `1`                            |
+| `image.repository`       | Repository for the Casdoor Docker image.                                                                  | `casbin`                       |
+| `image.name`             | Name of the Casdoor Docker image.                                                                         | `casdoor`                      |
+| `image.pullPolicy`       | Pull policy for the Casdoor Docker image.                                                                 | `IfNotPresent`                 |
+| `image.tag`              | Tag for the Casdoor Docker image.                                                                         | `""`                           |
+| `config`                 | Configuration settings for the Casdoor application.                                                       | See [config](https://github.com/casdoor/casdoor-helm/blob/master/charts/casdoor/values.yaml) field |
+| `database.driver`        | Database driver to use (supports mysql, postgres, cockroachdb, sqlite3).                                  | `sqlite3`                      |
+| `database.user`          | Database username.                                                                                        | `""`                           |
+| `database.password`      | Database password.                                                                                        | `""`                           |
+| `database.host`          | Database host.                                                                                            | `""`                           |
+| `database.port`          | Database port.                                                                                            | `""`                           |
+| `database.databaseName`  | Name of the database used by Casdoor.                                                                     | `casdoor`                      |
+| `database.sslMode`       | SSL mode for the database connection.                                                                     | `disable`                      |
+| `service.type`           | Type of Kubernetes service to create for Casdoor (ClusterIP, NodePort, LoadBalancer, etc.).               | `ClusterIP`                    |
+| `service.port`           | Port number for the Casdoor service.                                                                      | `8000`                         |
+| `ingress.enabled`        | Whether to enable Ingress for Casdoor.                                                                    | `false`                        |
+| `ingress.annotations`    | Annotations for the Ingress resource.                                                                     | `{}`                           |
+| `ingress.hosts`          | Hostnames for the Ingress resource.                                                                       | `[]`                           |
+| `resources`              | Resource requests and limits for the Casdoor container.                                                   | `{}`                           |
+| `autoscaling.enabled`    | Whether to enable Horizontal Pod Autoscaler for Casdoor.                                                  | `false`                        |
+| `autoscaling.minReplicas`| Minimum number of replicas for Horizontal Pod Autoscaler.                                                 | `1`                            |
+| `autoscaling.maxReplicas`| Maximum number of replicas for Horizontal Pod Autoscaler.                                                 | `100`                          |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage for Horizontal Pod Autoscaler.                      | `80`                           |
+| `nodeSelector`           | Node labels for pod assignment.                                                                           | `{}`                           |
+| `tolerations`            | Toleration labels for pod assignment.                                                                     | `[]`                           |
+| `affinity`               | Affinity settings for pod assignment.                                                                     | `{}`                           |
+| `extraContainersEnabled` | Whether to enable additional sidecar containers.                                                          | `false`                        |
+| `extraContainers`        | Additional sidecar containers.                                                                            | `""`                           |
+| `extraVolumeMounts`      | Additional volume mounts for the Casdoor container.                                                       | `[]`                           |
+| `extraVolumes`           | Additional volumes for the Casdoor container.                                                             | `[]`                           |
 
 ### Managing the Deployment
 


### PR DESCRIPTION
Add Documentation for Helm Chart Values. Other Open Source Solutions follow this pattern such as Bitnami for [redis](https://github.com/bitnami/charts/tree/main/bitnami/redis#parameters). It allows developers to quickly understand what to configure without digging into the helm chart code. After the latest feature release [PR](https://github.com/casdoor/casdoor-helm/pull/17), I learned a new database configuration should be referenced. Documenting it will ease the process