### PR TITLE
docs: clarify adapter and model relationship for permissions

### DIFF
--- a/docs/permission/permission-configuration.md
+++ b/docs/permission/permission-configuration.md
@@ -81,7 +81,7 @@ In Casdoor, adapters are **not configured per Permission**.
 The adapter and authorization behavior (such as RBAC or ABAC support) are defined at the **Model** level.
 A Permission only references a selected Model and provides policy data (subjects, resources, actions, effects).
 
-If RBAC-related fields (for example, *Sub users* or *Sub roles*) are disabled on the Permission page,
+If RBAC-related fields (for example, *Sub-users* or *Sub-roles*) are disabled on the Permission page,
 it means the selected Model does not define a `role_definition` or does not support RBAC.
 
 To use an adapter with a Permission:


### PR DESCRIPTION
### What this PR does
Clarifies that adapters are configured at the Model level and inherited by Permissions.

### Why
Users may expect to associate adapters directly with Permissions, but this is not supported by design.
This clarification helps avoid confusion when RBAC-related fields are disabled.

### Scope
Documentation-only change.

Fixes casdoor/casdoor#4693
