### PR TITLE
fix: add docs for 10 commits starting from 14b4b557 (2026-04-10)

### DIFF
--- a/docs/how-to-connect/oauth.md
+++ b/docs/how-to-connect/oauth.md
@@ -363,6 +363,40 @@ Example response:
 }
 ```
 
+## DPoP (sender-constrained tokens)
+
+Casdoor supports [DPoP (Demonstrating Proof of Possession, RFC 9449)](https://datatracker.ietf.org/doc/html/rfc9449), which binds an access token to a client-held key so that a leaked token cannot be used without the matching private key.
+
+To request a DPoP-bound token, send a `DPoP` header containing a DPoP proof JWT with your token request:
+
+```http
+POST /api/login/oauth/access_token
+DPoP: <DPoP proof JWT>
+```
+
+When a valid proof is supplied, Casdoor binds the issued token to the proof's public key (its JWK thumbprint, `jkt`) and returns `token_type` as `DPoP` instead of `Bearer`:
+
+```json
+{
+    "access_token": "eyJhb...",
+    "token_type": "DPoP",
+    "expires_in": 10080,
+    "scope": "openid"
+}
+```
+
+The same `DPoP` header is also accepted on the refresh token request. An invalid proof is rejected with the `invalid_dpop_proof` error.
+
+The supported proof signing algorithms are advertised in the OpenID Connect discovery document (`/.well-known/openid-configuration`) under `dpop_signing_alg_values_supported`:
+
+```json
+{
+    "dpop_signing_alg_values_supported": ["RS256", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+}
+```
+
+The [token introspection](#how-to-verify-access-token) response also exposes the key binding through the `cnf.jkt` claim (RFC 9449 §8).
+
 ## How to Verify Access Token
 
 Casdoor currently supports the [token introspection](https://datatracker.ietf.org/doc/html/rfc7662) endpoint. This endpoint is protected by Basic Authentication (ClientId:ClientSecret).


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `14b4b557`..`37e2f13d` (2026-04-10 → 2026-04-11), continuing from the previous "13 commits starting from c979a05c" batch. Ref: casdoor/casdoor#5629

## Documented

- **OAuth 2.0 DPoP (RFC 9449)** — casdoor/casdoor@d7bc2bf0. Added a "DPoP (sender-constrained tokens)" section to the OAuth guide covering the `DPoP` request header, the `DPoP` `token_type`, the `dpop_signing_alg_values_supported` discovery metadata, the `cnf.jkt` introspection claim, and the `invalid_dpop_proof` error.

## Reviewed, no docs needed

- `14b4b557` feat: support user's accessKey in auto signin filter — already covered by the "Access key and Access secret" section in `docs/basic/public-api.md` (User-scoped keys are documented).
- `29eeb03f`, `f5f4032b` — internal refactor / code format.
- `7006041f` — remove heartbeat logs.
- `c63184fc` upgrade to Antd 6.3.5 — dependency bump.
- `948fc017` improve i18n data.
- `5a5470d5`, `f35398ea`, `37e2f13d` — admin UI theme/icons/sidebar changes (no documented feature).

Note: the repo-wide `Markdown Lint` check reports pre-existing violations in unrelated files; the file changed here has no new violations.