### PR TITLE
ci: run Markdown Lint on push to master to match PR checks

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,6 +2,11 @@ name: Markdown Lint
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
   pull_request:
     paths:
       - 'docs/**'


### PR DESCRIPTION
The `Markdown Lint` workflow only runs on `pull_request` (and `workflow_dispatch`), not on `push`. As a result the lint is never evaluated on `master`: violations merged via PR are not re-checked, so `master` looks green while every new docs PR runs a full-tree lint and turns red on the accumulated debt (this is what caused the recent red checks, fixed in the docs cleanup).

This adds a `push` trigger on `master` (scoped to `docs/**`, same as the PR trigger) so the checks on `master` and on PRs are consistent. Master is currently lint-clean, so the first push run will pass.

```yaml
on:
  workflow_dispatch:
  push:
    branches:
      - master
    paths:
      - 'docs/**'
  pull_request:
    paths:
      - 'docs/**'
```

Note: `docs-links-check` is intentionally left PR-only — it validates external links in modified files and is prone to transient 403/timeout failures from third-party sites, which would produce flaky red runs on `master`.