### PR TITLE
fix: add docs for 10 commits starting from 8d0d8056 (2026-04-13)

### DIFF
--- a/docs/session/single-sign-on.md
+++ b/docs/session/single-sign-on.md
@@ -40,6 +40,8 @@ SSO works by opening your app’s home URL with a query parameter. Your app must
 
 **Popup sign-in** opens a small window for Casdoor login; after success it posts the auth result to the opener and closes. Use `popupSignin()` from [casdoor-js-sdk](https://github.com/casdoor/casdoor-js-sdk); demo: [casdoor-nodejs-react-example](https://github.com/casdoor/casdoor-nodejs-react-example). The home URL is called with `popup=1`; Casdoor sends `code` and `state` to the opener, and the main window exchanges them for a token via the SDK.
 
+By default Casdoor posts the result to `window.opener` (equivalent to `popup_type=window`). To embed the login inside an **iframe** instead of opening a separate window, add `popup_type=iframe` to the URL: Casdoor then posts the `code`/`state` message to `window.parent` (the embedding page's origin) rather than to `window.opener`.
+
 ## Using SSO
 
 The configuration is complete. Below, we will show you how to use auto login.


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `8d0d8056`..`1820758b` (2026-04-13 → 2026-04-17). Ref: casdoor/casdoor#5629

## Documented

- **Iframe popup sign-in** — casdoor/casdoor@69d5cc96 (#5400) added a `popup_type` parameter to popup sign-in. Extended the *Popup sign-in* section in `session/single-sign-on.md` to document `popup_type=iframe` (post the result to `window.parent` for iframe embedding) vs the default `popup_type=window`.

## Reviewed, no docs needed

The rest of the window is internal / bug fixes: authz form-data parsing (`8d0d8056`), MFA page UI (`4811b10d`), shared-application login fix (`72a0e5d1`), color-picker UI (`0a859d61`), mutual-exclusion login fix (`6dfbf1b3`), OpenClaw session graph internals (`11dc9b5f`), group-query DB ordering (`88358e1a`), and verification-code / forget-password login bug fixes (`4adcede1`, `1820758b`).