### PR TITLE
fix: add docs for 10 commits starting from 36281baa (2026-04-17)

### DIFF
--- a/docs/how-to-connect/oauth.md
+++ b/docs/how-to-connect/oauth.md
@@ -189,6 +189,8 @@ Casdoor also supports the [id_token](https://openid.net/specs/oauth-v2-multiple-
 
 For devices with limited input or no browser, use **Device Grant**. Enable it on the application, request `device_authorization_endpoint` from OIDC discovery, then show `verification_uri` (e.g. via QR or text) so the user can complete login.
 
+Casdoor provides a built-in device login page at the `verification_uri` where the user enters the user code and signs in — no custom UI is required. Device login can also be enabled as a sign-in method on the application's **Signin methods** table.
+
 Second, you should request `token endpoint` to get Access Token with parameter define in [rfc8628](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4).
 
 ### Resource Owner Password Credentials Grant

--- a/docs/ldap/config.md
+++ b/docs/ldap/config.md
@@ -52,7 +52,7 @@ Leave the list empty to return all attributes (default behavior).
 
 ## Default group
 
-Group to assign to users after sync.
+One or more groups to assign to users after sync. You can select multiple default groups; every synced user is added to all of them.
 
 :::caution
 If an LDAP user’s `uid` equals the `name` of an existing user in the organization, Casdoor creates a new user with a modified `name` (uid + random suffix). That user may not be able to sign in via LDAP because the LDAP server has no such `uid`. Avoid reusing existing Casdoor usernames as LDAP uids.

--- a/docs/pricing/coupon.md
+++ b/docs/pricing/coupon.md
@@ -1,0 +1,33 @@
+---
+title: Coupon
+description: Create discount coupons and apply them to orders at checkout.
+keywords: [coupon, discount, pricing, order, SaaS]
+authors: [hsluoyz]
+---
+
+**Coupons** let you offer discounts that customers redeem with a code at checkout. Manage them on the **Coupons** page in the Casdoor admin sidebar.
+
+## Coupon fields
+
+| Field | Description |
+|-------|-------------|
+| Code | The unique code the customer enters at checkout |
+| Discount type | `Percentage` (0–100) or `Fixed` amount |
+| Discount | The discount value (percent or fixed amount) |
+| Max discount | Cap for percentage coupons (`0` = unlimited) |
+| Scope | `universal` (any order), `product` (specific products), or `user` (specific users) |
+| Products / Users | The products or users the coupon applies to, when the scope is `product` or `user` |
+| Quantity | Total number that can be issued (`0` = unlimited) |
+| Max usage per user | How many times one user may use it (`0` = unlimited) |
+| Min order amount | Minimum order total required to apply the coupon |
+| Currency | Currency the coupon applies to |
+| Start / Expire time | The validity window |
+| State | Whether the coupon is active |
+
+## How it works
+
+1. Create a coupon on the **Coupons** page and share its **Code**.
+2. At checkout, the customer enters the code on their order.
+3. Casdoor validates the coupon — scope, validity window, minimum order amount, quantity, and per-user usage limit — and applies the discount to the order total.
+
+Each redemption is recorded so that quantity and per-user usage limits are enforced.

--- a/docs/provider/oauth/overview.md
+++ b/docs/provider/oauth/overview.md
@@ -57,3 +57,7 @@ After OAuth sign-in, Casdoor stores the provider’s access token on the user. Y
 1. Open **Applications**, edit the application.
 2. Add the provider and set its rules (e.g. enable for login, signup, unbind).
 3. Save.
+
+## Routing through a proxy
+
+Enable **Enable proxy** on the provider to route its outbound HTTP requests (the OAuth login API calls) through Casdoor's configured SOCKS5 proxy (`socks5Proxy` in `conf/app.conf`). This is useful when the provider is only reachable through a proxy. Some provider types always use the proxy regardless of this option.

--- a/sidebars.js
+++ b/sidebars.js
@@ -423,6 +423,7 @@ module.exports = {
         "pricing/pricing",
         "pricing/subscription",
         "pricing/transaction",
+        "pricing/coupon",
       ],
     },
     {


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `36281baa`..`e1d81e4c` (2026-04-17 → 2026-04-18). Ref: casdoor/casdoor#5629

## Documented

- **Coupon system** — @36281baa (#5397): percentage/fixed discount, universal/product/user scope, quantity and per-user usage limits, minimum order amount, validity window. New page `docs/pricing/coupon.md` + **Coupon** sidebar entry.
- **OAuth provider proxy option** — @71a6ba93: added an *Enable proxy* note to `provider/oauth/overview.md` (route a provider's outbound HTTP through the `socks5Proxy` in `conf/app.conf`).
- **Device login page** — @e887e639 (#5413): extended the *Device Grant* section in the OAuth guide to note the built-in device login page at `verification_uri` and that device login can be enabled as a sign-in method.
- **Multiple default LDAP groups** — @e1d81e4c: updated `ldap/config.md` *Default group* to note that multiple default groups can be assigned.

## Reviewed, no docs needed

Bug fixes / README / UI: `d08de110`, `b28f536c`, `7a6b2cb3`, `a68b4d48`, `64aad688`, `da23aaaf`.