### PR TITLE
fix: add docs for 10 commits starting from 927735f4 (2026-04-20)

### DIFF
--- a/docs/key/overview.md
+++ b/docs/key/overview.md
@@ -27,6 +27,7 @@ authors: [hsluoyz]
 - **Organization** — Key is valid for all operations within the organization.
 - **Application** — Key is scoped to a specific application within the organization.
 - **User** — Key is tied to a specific user and carries that user's permissions.
+- **Prometheus** — Key that authorizes scraping the [Prometheus metrics endpoint](/docs/monitoring/prometheus) (`/api/metrics`).
 
 ## Managing keys
 

--- a/docs/monitoring/Prometheus.md
+++ b/docs/monitoring/Prometheus.md
@@ -19,7 +19,12 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:8000']   # Casdoor backend address
     metrics_path: '/api/metrics'
+    params:
+      accessKey: ['<your-access-key>']
+      accessSecret: ['<your-access-secret>']
 ```
+
+`/api/metrics` requires authentication: it can be called by an admin browser session, or by a **Prometheus**-type [key](/docs/key/overview). Create a Prometheus key on the **Keys** page and pass its `accessKey` and `accessSecret` as query parameters (the `params` block above adds them to each scrape request).
 
 After Prometheus is running and scraping, you can query and visualize Casdoor metrics (e.g. in Grafana).
 


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `927735f4`..`c487a2b3` (2026-04-20 → 2026-04-23). Ref: casdoor/casdoor#5629

## Documented

- **Prometheus key type** — casdoor/casdoor@927735f4: `/api/metrics` is now access-protected and can be called by a **Prometheus**-type key (accessKey/accessSecret) in addition to an admin session. Added the `Prometheus` key type to `key/overview.md`, and updated `monitoring/Prometheus.md` with the auth requirement and a scrape-config `params` example.

## Reviewed, no docs needed

- `6b376d0a` (#5420) OpenClaw transcript storage/viewer — internal OpenClaw admin tooling.
- `1c082194` fetch OAuth token in MCP server edit page — admin UI.
- The rest are bug fixes / UI (`7816c29a`, `17cb08fb`, `83bc1084`, `9f96ffe8`, `e4480215`, `e1859513`, `c487a2b3`).

## Note on the previous window

The preceding 10-commit window (`9fe2986d`..`bcd00dc1`, 2026-04-18 → 20) was reviewed and contained only bug fixes and internal changes (org-admin authz refinement #5416, CORS/SAML redirect validation, Alipay cert bug fixes — Alipay cert config is already documented), so it produced no docs.