### PR TITLE
fix: add docs for 10 commits starting from b87add5f (2026-04-23)

### DIFF
--- a/docs/application/terminology.md
+++ b/docs/application/terminology.md
@@ -62,6 +62,7 @@ The application edit page is split into eight tabs. Fields below are grouped by 
 - **SAML reply URL** — Assertion Consumer Service (ACS) URL where Casdoor posts the SAML response.
 - **Enable SAML compression** — Compress SAML requests and responses.
 - **Enable SAML C14N10** — Use C14N 1.0 canonicalization when signing SAML documents.
+- **SAML C14N prefix** — Namespace prefix list used for the C14N 1.0 canonicalization (applies when **Enable SAML C14N10** is on; default `xs`).
 - **Use Email as NameID** — Use the user's email address as the SAML `NameID` instead of username.
 - **Enable SAML POST binding** — Use HTTP POST binding instead of Redirect binding.
 - **SAML hash algorithm** — Signature hash algorithm: SHA1, SHA256, or SHA512.

--- a/docs/session/single-sign-out.mdx
+++ b/docs/session/single-sign-out.mdx
@@ -116,6 +116,12 @@ To receive logout notifications, configure a notification provider (such as Cust
 
 Your application can then verify the signature, check the timestamp to prevent replay attacks, and use the session IDs and token hashes to perform targeted logout operations. For more details on configuring notification providers, see the [Notification Providers](/docs/provider/notification/overview) documentation.
 
+## OIDC Back-Channel Logout
+
+Casdoor supports [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html). When a user logs out (RP-initiated logout), Casdoor sends a signed **logout token** to every application that has an active session for the user, so each application can end its own session server-to-server.
+
+To enable it, set the application's **Backchannel logout URI** (`backchannelLogoutUri`) to the endpoint that receives the logout token. Casdoor sends an HTTP `POST` with a `logout_token` (a JWT containing the `sub`, `sid`, and the `http://schemas.openid.net/event/backchannel-logout` event) to that URI. Applications that do not set a backchannel logout URI are skipped.
+
 ## SSO Logout API
 
 ### Endpoint


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `b87add5f`..`fd073504` (2026-04-23 → 2026-04-27). Ref: casdoor/casdoor#5629

## Documented

- **OIDC Back-Channel Logout 1.0** — @9489fc3d: section in `session/single-sign-out.mdx` (application `backchannelLogoutUri`; Casdoor POSTs a signed `logout_token` on RP-initiated logout).
- **Native SSO** — @783cd642 (#5438): *Native SSO* section in the OAuth guide (OIDC Native SSO for Mobile Apps 1.0 — `device_sso` scope + `device_secret`, token-exchange with `actor_token_type=urn:openid:params:token-type:device-secret`, completed via `/api/native-sso-complete`).
- **SAML C14N prefix** — @fd073504: `SamlC14nPrefix` field in `application/terminology.md`.

## Handled in #999

- `0b56ef90` (#5430) new Scan Provider type **Security Scan** — added to the Scan provider page in #999 (where that page is introduced), keeping all Scan types on one page.

## Reviewed, no docs needed

Internal / bug fixes: `b87add5f`, `d9959f25`, `f98b6427`, `587cd5b3`, `4319b979`, `be110c93`.