### PR TITLE
fix: add docs for 10 commits starting from 12245928 (2026-04-27)

### DIFF
--- a/docs/application/terminology.md
+++ b/docs/application/terminology.md
@@ -93,6 +93,7 @@ Each OAuth / Web3 / SAML provider entry in the provider table has additional per
 - **Signin methods** — Ordered list of sign-in methods shown on the login page (e.g. Password, Verification code, WebAuthn).
 - **Signup HTML** — Custom HTML injected into the sign-up page.
 - **Signin HTML** — Custom HTML injected into the sign-in page.
+- **Page HTML** — Custom HTML injected into the page `<head>` (e.g. meta tags, analytics snippets, or custom styles/scripts) for all of the application's pages.
 - **Signin items** — Configure which fields and controls appear on the sign-in form.
 - **Signup items** — Configure the registration form fields (visible only when **Enable signup** is on).
 - **Background URL** — Desktop login page background image (URL + preview).


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `12245928`..`b6ee82bf` (2026-04-27 → 2026-04-28). Ref: casdoor/casdoor#5629

## Documented

- **Application Page HTML** — @5a969f28: added the **Page HTML** field to the *UI Customization* section of `application/terminology.md` (custom HTML injected into the page `<head>` for all of the application's pages).

## Reviewed, no docs needed

- `b6ee82bf` support camelCase in the `/api/update-user` `columns` arg — a minor input-parsing improvement (the arg already accepted snake_case; its format isn't specified in the docs).
- `12245928`, `3f1264f1`, `02fcf4a7`, `181d2d5c`, `5302f468`, `fa770c3a`, `01d58bae`, `6ad48fd5` — bug fixes and internal changes (UpdateUser partial-column fix, IsAllowed() panic/error handling, avatar helpers, getWebBuildFolder, syncer memory, SnakeString removal).