### PR TITLE
fix: add docs for 10 commits starting from 50d3dc4f (2026-05-11)

### DIFF
--- a/docs/application/terminology.md
+++ b/docs/application/terminology.md
@@ -46,7 +46,7 @@ The application edit page is split into eight tabs. Fields below are grouped by 
 - **Client secret** — OAuth 2.0 client secret.
 - **Redirect URLs** — Allowed post-login redirect URIs. Matching is URL-based: scheme, port, and path must match exactly, and the host may be the configured host or any subdomain of it (e.g. configuring `https://example.com/callback` also allows `https://api.example.com/callback`). Entries that are not valid URLs are matched as anchored regular expressions.
 - **Forced redirect origin** — When set, Casdoor forces all redirects to this origin.
-- **Grant types** — Enabled OAuth grant types: Authorization Code, Password, Client Credentials, Token, ID Token, Refresh Token, Device Code, JWT Bearer.
+- **Grant types** — Enabled OAuth grant types: Authorization Code, Password, Client Credentials, Token, ID Token, Refresh Token, Device Code, Token Exchange, JWT Bearer.
 - **Scopes** — Custom scopes for Agent-category apps (name, display name, description); exposed in OIDC discovery.
 - **Token format** — `JWT`, `JWT-Empty`, `JWT-Custom`, or `JWT-Standard`. See [Token overview](/docs/token/overview).
 - **Token signing method** — Signing algorithm: RS256, RS512, ES256, ES384, or ES512.

--- a/docs/developer-guide/swagger.md
+++ b/docs/developer-guide/swagger.md
@@ -7,6 +7,10 @@ authors: [ComradeProgrammer]
 
 Casdoor is built on **beego**, which uses the **bee** CLI to generate Swagger files. The default bee does not group APIs by tag; Casdoor uses a [modified bee](https://github.com/casbin/bee) that supports the `@Tag` label so APIs are grouped in the generated docs.
 
+:::note
+The built-in Swagger UI at `/swagger` is only served when Casdoor runs in **dev** run mode (`runmode = dev` in `conf/app.conf`). It is not exposed in production.
+:::
+
 ## Comment format
 
 Use the same comment style as standard bee; the only extra requirement is **@Tag** so APIs are grouped. Example:

--- a/docs/scim/overview.md
+++ b/docs/scim/overview.md
@@ -9,7 +9,7 @@ authors: [Chinoholo0807]
 
 ## Supported resources
 
-Casdoor currently supports the **User** resource only. You manage users with these endpoints:
+Casdoor supports the **User** and **Group** resources. Manage them with these endpoints:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -22,6 +22,12 @@ Casdoor currently supports the **User** resource only. You manage users with the
 | `/scim/Users/:id` | PUT | Replace user |
 | `/scim/Users/:id` | PATCH | Partial update |
 | `/scim/Users/:id` | DELETE | Delete user |
+| `/scim/Groups/:id` | GET | Get group by id |
+| `/scim/Groups` | GET | List groups (query params: `startIndex`, `count`) |
+| `/scim/Groups` | POST | Create group |
+| `/scim/Groups/:id` | PUT | Replace group |
+| `/scim/Groups/:id` | PATCH | Partial update |
+| `/scim/Groups/:id` | DELETE | Delete group |
 
 See [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644) for the full SCIM spec.
 


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `50d3dc4f`..`07cf4d3c` (2026-05-11 → 2026-05-15). Ref: casdoor/casdoor#5629

## Documented

- **SCIM groups** — @89773d39: added the `/scim/Groups` endpoints to `scim/overview.md` (Casdoor's SCIM server now supports the Group resource in addition to User).
- **Swagger UI is dev-only** — @e0027580 (#5462): noted in `developer-guide/swagger.md` that the built-in `/swagger` UI is only served in `dev` run mode, not in production.
- **Token Exchange grant option** — @84e2ff01: added **Token Exchange** to the *Grant types* list in `application/terminology.md` (it is now selectable in the application edit page).

## Reviewed, no docs needed

- `5403f76a` add group's `Properties` field — key/value metadata field with no dedicated field reference to update.
- `07cf4d3c` CustomScopeTable in app edit page — UI for the already-documented custom scopes.
- Bug fixes / internal: `50d3dc4f`, `fc03a30e`, `20aa3d48`, `72dc509e`, `84720398`.

## Previous window

The preceding 10-commit window (`05c287a1`..`eaae1ba7`, 2026-04-28 → 05-09) was all bug fixes / internal / CI (white-screen fix, COS upload, API default fields, UploadPermissions filter, XLSX import, impersonate authz), so it produced no docs.