### PR TITLE
fix: add docs for 10 commits starting from e0feffd6 (2026-05-19)

### DIFF
--- a/docs/application/dynamic-client-registration.md
+++ b/docs/application/dynamic-client-registration.md
@@ -90,6 +90,8 @@ The registration endpoint itself requires no authentication—this is by design 
 
 Applications created through DCR belong to the organization's admin account and appear in your application list with a `dcr` tag. This tag is not just a label: DCR-registered applications run under a restricted `app-dcr` role and can only reach the OAuth/OIDC endpoints they need for the login flow (`/api/login/oauth/*`, `/api/get-oauth-token`, `/api/userinfo`, `/api/get-application`). They cannot use the client credentials to call other management APIs, which limits the blast radius of a self-registered client.
 
+So that end users can actually sign in to a self-registered app, DCR-registered applications have password sign-in enabled and inherit the OAuth/OIDC providers and sign-in methods of the organization's default application.
+
 Client secrets never expire by default, but you can revoke any application through the admin interface at any time. For production deployments, consider whether your organization actually needs unauthenticated registration. Many scenarios work fine with manual app creation, and leaving DCR disabled removes a potential abuse vector.
 
 ## Complete Example: MCP Client


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `e0feffd6`..`0585ecff` (2026-05-19 → 2026-05-24). Ref: casdoor/casdoor#5629

## Documented

- **DCR app login inheritance** — @bde37776: noted in `application/dynamic-client-registration.md` that DCR-registered apps have password sign-in enabled and inherit the default application's providers and sign-in methods.

## Reviewed, no docs needed

- `4034fc79` add Languages to signup items — an optional signup item; the signup-items doc describes item configuration generically rather than enumerating every available item, so there is no list to append to.
- `866c2143` org language on signup page, `0585ecff` browser language detection, `627f9b42` "Get Code" i18n, `76386b41` form_css `<style>` rendering — UI / i18n.
- `88fb414c`, `3cb60836`, `e0feffd6`, `262bd148` — internal / swagger / CI.