### PR TITLE
fix: add docs for 10 commits starting from a465c084 (2026-05-26)

### DIFF
--- a/docs/how-to-connect/mcp/tools.md
+++ b/docs/how-to-connect/mcp/tools.md
@@ -144,6 +144,18 @@ The MCP server currently provides these application management tools:
 }
 ```
 
+## User Management Tools
+
+The MCP server also provides user management tools, mirroring the application tools:
+
+- **get_users** — List all users in an organization (argument: `owner`).
+- **get_user** — Get one user by `id`, or by `owner` + `email`, or `owner` + `phone`.
+- **add_user** — Create a user (argument: `user` object).
+- **update_user** — Modify an existing user (arguments: `id` and `user` object).
+- **delete_user** — Delete a user (argument: `user` object).
+
+They are called the same way as the application tools — via `tools/call` with the tool `name` and `arguments`. As with the other tools, results are subject to the caller's auth and scopes.
+
 ## Response Format
 
 Tool calls return results in a structured format:

--- a/docs/permission/permission-configuration.md
+++ b/docs/permission/permission-configuration.md
@@ -101,6 +101,15 @@ Using roles is a powerful way to manage permissions at scale. Instead of assigni
 
 :::
 
+#### Sub groups
+
+Which groups the permission applies to; select them on the **Edit Permission** page. Every user who is a member of a selected group inherits the permission. Use `*` to match all groups in the organization.
+
+Examples:
+
+- Select groups like `dev-team`, `qa-team`
+- Leave empty to not restrict by group
+
 #### Sub domains
 
 Which domains will the permission policy be applied to. This is useful for multi-tenant scenarios.


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `a465c084`..`7b5d5005` (2026-05-26 → 2026-05-29). Ref: casdoor/casdoor#5629

## Documented

- **Groups in permissions** — @199ba20e (#5525): added a **Sub groups** subsection to `permission/permission-configuration.md` (a permission can now apply to groups; members of the selected groups inherit it, `*` matches all).
- **MCP user tools** — @7b5d5005: added a **User Management Tools** section to `how-to-connect/mcp/tools.md` (`get_users`, `get_user`, `add_user`, `update_user`, `delete_user`).

## Reviewed, no docs needed

- `a465c084`, `6ddbc180`, `25f7cd8d`, `684564f4` — phone login: normalize/lookup by E.164 with countryCode (behavior improvements, no config/UI to document).
- `86eb36d0` allow org admin to sync LDAP users, `c3fe0aea` backtick `groups` column (MySQL 8), `5586768c` GetMaskedCert, `d08415bf` i18n.