### PR TITLE
fix: add docs for 10 commits starting from 8e75babe (2026-05-29)

### DIFF
--- a/docs/application/terminology.md
+++ b/docs/application/terminology.md
@@ -28,6 +28,7 @@ The application edit page is split into eight tabs. Fields below are grouped by 
 
 - **Cookie expire** — Session cookie lifetime in hours (default: 720). Without "Remember me", the session is capped at 24 h regardless.
 - **Default group** — Group automatically assigned to new users signing up through this application, including both direct sign-up and OAuth-based registration. Providers and invitations can override this per-signup: the effective group follows the priority **invitation SignupGroup > provider SignupGroup > application Default group**.
+- **Default tag** — Tag automatically assigned to new users who sign up through this application.
 - **Enable signup** — Allow self sign-up. When off, only admins can create accounts.
 - **Disable signin** — Disable all sign-in for this application.
 - **Enable guest signin** — Allow unauthenticated guest access by presenting `code=guest-user` to the token endpoint. Requires **Enable signup** to be on as well. Not available for the `built-in` organization. See [Guest authentication](/docs/how-to-connect/guest-auth).


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `8e75babe`..`e81acfc1` (2026-05-29 → 2026-06-04). Ref: casdoor/casdoor#5629

## Documented

- **Default tag** — @981d17c7: added the **Default tag** application field to `application/terminology.md` (tag auto-assigned to new users signing up through the app).

## Reviewed, no docs needed

- `e81acfc1` Tag signup item — optional signup item (like Languages in the previous batch), no item list to append to.
- `8e75babe` / `7f5d8f6d` DCR inherits branding / signin-session / WebAuthn from the default app — extends the DCR login-inheritance already noted in the DCR guide (PR #1007); flagging here rather than re-editing the same paragraph in an unmerged PR.
- `fc97bb69` (#5515) send backchannel logout before expiring tokens — ordering fix for the already-documented back-channel logout.
- `a0ace4d6` respect `?columns=` in update-application, `6bfbad5e`, `71fda8d3`, `7d285350`, `094c359a` — internal / UI.