### PR TITLE
fix: add docs for 10 commits starting from de99597a (2026-06-13)

### DIFF
--- a/docs/ldap/config.md
+++ b/docs/ldap/config.md
@@ -40,6 +40,8 @@ When **Enable groups** is turned on, Casdoor queries the LDAP directory for grou
 
 Group sync runs before user sync in each auto-sync cycle so that groups exist before user membership is evaluated. If a group lookup fails, the error is logged and the rest of the sync continues.
 
+Syncing a user adds them to their LDAP groups without removing groups they already belong to that are not managed by LDAP, so manually assigned groups are preserved.
+
 ## LDAP server attribute filtering
 
 By default, Casdoor's built-in LDAP server exposes all standard attributes for each user entry. You can restrict which attributes are returned by setting **LDAP attributes** on the organization edit page.


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `de99597a`..`c09015f4` (2026-06-13 → 2026-06-17). Ref: casdoor/casdoor#5629

## Documented

- **LDAP preserves existing groups** — @fa7594ce (#5580): noted in `ldap/config.md` that syncing a user no longer removes groups they already belong to that are not managed by LDAP.

## Reviewed, no docs needed

- `c0eb9f70` return the token's issuing `client_id` in the introspection response — the introspection response fields aren't enumerated in the docs; standard RFC 7662 field.
- `c09015f4` put session id in `sid` (not `jti`) in the backchannel logout token — the back-channel logout doc already describes the `sid` claim.
- `0e4d8202` (#5575) WeCom Silent auth `agentid`, `9fb1b002` scope length 300, `80b0a306` per-app OIDC issuer alignment, `a199b8e7` MustCols — internal / provider details.

## Previous window

The preceding 10-commit window (`08fe8d1c`..`c1a76003`, 2026-06-04 → 06-12) was internal / bug fixes / a revert (including reverting the native-sso PR #5438, and self-hosting the Inter font), so it produced no docs.