### PR TITLE
fix: add docs for 10 commits starting from 9ad2b8ca (2026-06-17)

### DIFF
--- a/docs/application/dynamic-client-registration.md
+++ b/docs/application/dynamic-client-registration.md
@@ -75,6 +75,14 @@ Your registration request needs at least one redirect URI. Everything else is op
 
 Applications created through DCR get a 7-day token expiration and are tagged with `dcr` for easy identification in the admin interface.
 
+## Managing a registered client
+
+Casdoor also implements [RFC 7592](https://datatracker.ietf.org/doc/html/rfc7592) so a client can read, update, or delete its own registration at `/api/oauth/register/{client_id}`:
+
+- `GET /api/oauth/register/{client_id}` — read the client's current metadata.
+- `PUT /api/oauth/register/{client_id}` — update the client's metadata.
+- `DELETE /api/oauth/register/{client_id}` — delete the client.
+
 ## Controlling DCR Per Organization
 
 Organizations control whether DCR is available through the `dcrPolicy` setting on the organization configuration page. Two values are supported:

--- a/docs/provider/faceid/overview.md
+++ b/docs/provider/faceid/overview.md
@@ -11,5 +11,7 @@ Casdoor supports Face ID as a sign-in method. Only enable it when you can ensure
 
 1. Open the Casdoor admin UI → **Providers** → **Add**.
 2. Set **Category** to **Face ID**.
-3. Choose the **Type** (e.g. Alibaba Cloud FaceBody).
-4. Fill in the required fields (e.g. **Client ID**, **Client Secret**, **Endpoint** as needed) and save.
+3. Choose the **Type**:
+   - **Alibaba Cloud Facebody** — cloud face recognition (requires the provider's credentials/endpoint).
+   - **Local UniFace** — on-device face recognition using the [UniFace](https://github.com/yakhyo/uniface) model, with no external service.
+4. Fill in the required fields (e.g. **Client ID**, **Client Secret**, **Endpoint** for cloud types) and save.


### PR DESCRIPTION
Docs sync batch for casdoor/casdoor commits `9ad2b8ca`..`53033b46` (2026-06-17 → 2026-06-28). Ref: casdoor/casdoor#5629

## Documented

- **RFC 7592 DCR management** — @13bc7a0e: added a *Managing a registered client* section to `application/dynamic-client-registration.md` (`GET/PUT/DELETE /api/oauth/register/{client_id}`).
- **Local UniFace Face ID** — @8af1a62e (#5588): added the **Local UniFace** on-device type to `provider/faceid/overview.md` (alongside the cloud Alibaba Cloud Facebody type).

## Reviewed, no docs needed

- `c0ccc697` make `id_token_hint` optional for OIDC RP-initiated logout — the RP-initiated (`end_session`) flow isn't documented as its own section today, so there's nothing to amend.
- `9ad2b8ca` TokenFields whitelist on userinfo, `53033b46` mask org fields for normal users, `98b6011b` DeviceAuthMap via Redis (multi-replica) — internal / behavior.
- `5eec173f`, `6e443ad5` (#5596), `696bcf05` (#5600), `8449a357` — bug fixes / internal.